### PR TITLE
Add experimental ceiling fan support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .vscode
+.project
+.classpath
+.settings
 src/main/history
 target

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ Color LivingRoom_Light_Color "Living Room Lamp" (gLivingroom) {channel="wizlight
 
 ## Changelog
 
+### Version 4.0.0.03
+
+- TODO
+
 ### Version 4.0.0.02
 - 4.0.0.01 incorrectly reported it's version as 3.4.0.01, this has been fixed and updated to 4.0.0.02
 - Openhab 4.0 compatability tested and confirmed

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <artifactId>org.openhab.binding.wizlighting</artifactId>
 
   <!-- Version appended to openhab-addons version -->
-  <version>4.0.0.02</version>
+  <version>4.0.0.03-SNAPSHOT</version>
 
   <name>openHAB Add-ons :: Bundles :: WiZ Lighting Binding</name>
 

--- a/src/main/java/org/openhab/binding/wizlighting/internal/WizLightingBindingConstants.java
+++ b/src/main/java/org/openhab/binding/wizlighting/internal/WizLightingBindingConstants.java
@@ -33,7 +33,7 @@ public class WizLightingBindingConstants {
      * The binding id.
      */
     public static final String BINDING_ID = "wizlighting";
-    public static final String CURRENT_BINDING_VERSION = "v4.0.0.02";
+    public static final String CURRENT_BINDING_VERSION = "v4.0.0.03";
 
     /**
      * List of all Thing Type UIDs.
@@ -42,12 +42,14 @@ public class WizLightingBindingConstants {
     public static final ThingTypeUID THING_TYPE_WIZ_TUNABLE_BULB = new ThingTypeUID(BINDING_ID, "wizTunableBulb");
     public static final ThingTypeUID THING_TYPE_WIZ_DIMMABLE_BULB = new ThingTypeUID(BINDING_ID, "wizDimmableBulb");
     public static final ThingTypeUID THING_TYPE_WIZ_SMART_PLUG = new ThingTypeUID(BINDING_ID, "wizPlug");
+    public static final ThingTypeUID THING_TYPE_WIZ_CEILING_FAN = new ThingTypeUID(BINDING_ID, "wizCeilingFan");
 
     /**
      * The supported thing types.
      */
-    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Stream.of(THING_TYPE_WIZ_COLOR_BULB,
-            THING_TYPE_WIZ_TUNABLE_BULB, THING_TYPE_WIZ_DIMMABLE_BULB, THING_TYPE_WIZ_SMART_PLUG)
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Stream
+            .of(THING_TYPE_WIZ_COLOR_BULB, THING_TYPE_WIZ_TUNABLE_BULB, THING_TYPE_WIZ_DIMMABLE_BULB,
+                    THING_TYPE_WIZ_SMART_PLUG, THING_TYPE_WIZ_CEILING_FAN)
             .collect(Collectors.toSet());
 
     /**
@@ -61,6 +63,10 @@ public class WizLightingBindingConstants {
     public static final String CHANNEL_DYNAMIC_SPEED = "speed";
     public static final String CHANNEL_RSSI = "signalstrength";
     public static final String CHANNEL_LAST_UPDATE = "lastUpdate";
+    public static final String CHANNEL_FAN_STATE = "fanState";
+    public static final String CHANNEL_FAN_SPEED = "fanSpeed";
+    public static final String CHANNEL_FAN_MODE = "fanMode";
+    public static final String CHANNEL_FAN_REVERSE = "fanRevrs";
 
     // -------------- Configuration arguments ----------------
     /**

--- a/src/main/java/org/openhab/binding/wizlighting/internal/discovery/WizLightingDiscoveryService.java
+++ b/src/main/java/org/openhab/binding/wizlighting/internal/discovery/WizLightingDiscoveryService.java
@@ -193,6 +193,13 @@ public class WizLightingDiscoveryService extends AbstractDiscoveryService {
                     logger.trace("New bulb appears to be a tunable white bulb and will be given the UUID: {}",
                             newThingId);
 
+                    // Check for "FANDIMS" as in confirmed example ESP03_FANDIMS_31 for Faro Barcelona Smart Fan
+                } else if (discoveredModel.contains("FANDIMS")) {
+                    thisBulbType = THING_TYPE_WIZ_CEILING_FAN;
+                    thisBulbLabel = "WiZ Smart Fan at " + lightIpAddress;
+                    newThingId = new ThingUID(thisBulbType, lightMacAddress);
+                    logger.trace("New device appears to be a smart fan and will be given the UUID: {}", newThingId);
+
                     // We key off "RGB" for color bulbs
                 } else if (!discoveredModel.contains("RGB")) {
                     thisBulbType = THING_TYPE_WIZ_DIMMABLE_BULB;

--- a/src/main/java/org/openhab/binding/wizlighting/internal/entities/FanStateRequestParam.java
+++ b/src/main/java/org/openhab/binding/wizlighting/internal/entities/FanStateRequestParam.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.wizlighting.internal.entities;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.google.gson.annotations.Expose;
+
+/**
+ * This POJO represents Fan State Request Param
+ */
+@NonNullByDefault
+public class FanStateRequestParam implements Param {
+    @Expose(serialize = true, deserialize = true)
+    private int fanState; // true = 1, false = 0
+
+    public FanStateRequestParam(int fanState) {
+        this.fanState = fanState;
+    }
+
+    public int getFanState() {
+        return fanState;
+    }
+
+    public void setFanState(int fanState) {
+        this.fanState = fanState;
+    }
+}

--- a/src/main/java/org/openhab/binding/wizlighting/internal/entities/WizLightingSyncState.java
+++ b/src/main/java/org/openhab/binding/wizlighting/internal/entities/WizLightingSyncState.java
@@ -15,7 +15,7 @@ package org.openhab.binding.wizlighting.internal.entities;
 import static org.openhab.binding.wizlighting.internal.WizLightingBindingConstants.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.openhab.binding.wizlighting.internal.enums.*;
+import org.openhab.binding.wizlighting.internal.enums.WizLightingColorMode;
 import org.openhab.binding.wizlighting.internal.utils.WizColorConverter;
 import org.openhab.core.library.types.HSBType;
 import org.openhab.core.library.types.PercentType;
@@ -94,6 +94,15 @@ public class WizLightingSyncState {
     // Indicates if the light mode is applied following a pre-set "rhythm"
     @Expose(serialize = true, deserialize = true)
     public int schdPsetId;
+
+    @Expose(serialize = true, deserialize = true)
+    public int fanState;
+    @Expose(serialize = true, deserialize = true)
+    public int fanSpeed;
+    @Expose(serialize = true, deserialize = true)
+    public int fanMode;
+    @Expose(serialize = true, deserialize = true)
+    public int fanRevrs;
 
     public WizLightingColorMode getColorMode() {
         if (r != 0 || g != 0 || b != 0) {

--- a/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/src/main/resources/OH-INF/thing/thing-types.xml
@@ -73,6 +73,17 @@
 		<config-description-ref uri="thing-type:wiz:light"/>
 	</thing-type>
 
+	<!-- WiFi Smart Ceiling Fan Thing Type -->
+	<thing-type id="wizCeilingFan">
+		<label>WiZ Ceiling Fan</label>
+		<description>Supports WiZ Ceiling Fans</description>
+
+		<channels>
+			<channel id="fanState" typeId="system.power"/>
+		</channels>
+		<config-description-ref uri="thing-type:wiz:light"/>
+	</thing-type>
+
 	<!-- Bulb Channel Types -->
 	<channel-type id="lightMode">
 		<item-type>String</item-type>


### PR DESCRIPTION
fixes #3 [work in progress]

This is a rudimentary working implementation of ceiling support for wiz. the only supported channel right now is `fanState`.

There is an issue when updating the state right after posting an update still returned the old state. Adding `Thread.sleep(..)` fixed this but is less than ideal.
