### PR TITLE
Fan Mode, Speed, and Reverse channels

### DIFF
--- a/src/main/java/org/openhab/binding/wizlighting/internal/entities/FanModeRequestParam.java
+++ b/src/main/java/org/openhab/binding/wizlighting/internal/entities/FanModeRequestParam.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.wizlighting.internal.entities;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.google.gson.annotations.Expose;
+
+/**
+ * This POJO represents one Fan Mode Request Param
+ *
+ * The outgoing JSON should look like this:
+ *
+ * {"id": 22, "method": "setPilot", "params": {"fanMode": 2}}
+ *
+ * @see org.openhab.binding.wizlighting.internal.enums.WizLightingFanMode
+ */
+@NonNullByDefault
+public class FanModeRequestParam extends StateRequestParam {
+    @Expose(serialize = true, deserialize = true)
+    private int fanMode;
+
+    public FanModeRequestParam(int sceneId) {
+        super(true);
+        this.fanMode = sceneId;
+    }
+
+    public int getFanMode() {
+        return fanMode;
+    }
+
+    public void setFanMode(int fanMode) {
+        this.fanMode = fanMode;
+    }
+}

--- a/src/main/java/org/openhab/binding/wizlighting/internal/entities/FanReverseRequestParam.java
+++ b/src/main/java/org/openhab/binding/wizlighting/internal/entities/FanReverseRequestParam.java
@@ -17,32 +17,31 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import com.google.gson.annotations.Expose;
 
 /**
- * This POJO represents one Fan Mode Request Param
+ * This POJO represents Fan Reverse ({@code fanRevrs}) Request Param
  *
  * The outgoing JSON should look like this:
  *
- * {"id": 22, "method": "setPilot", "params": {"fanMode": 2}}
+ * {"id": 23, "method": "setPilot", "params": {"fanState": 1,"fanRevrs": 1}}
  *
  * extends {@link FanStateRequestParam} to always set {@code fanState}, similar to {@link DimmingRequestParam} and usual
  * fan remote behavior
- *
- * @see org.openhab.binding.wizlighting.internal.enums.WizLightingFanMode
  */
 @NonNullByDefault
-public class FanModeRequestParam extends FanStateRequestParam {
+public class FanReverseRequestParam extends FanStateRequestParam {
+
     @Expose(serialize = true, deserialize = true)
-    private int fanMode;
+    private int fanRevrs; // true = 1, false = 0
 
-    public FanModeRequestParam(int sceneId) {
-        super(1);
-        this.fanMode = sceneId;
+    public FanReverseRequestParam(int fanRevrs) {
+        super(1); // fanState = 1
+        this.fanRevrs = fanRevrs;
     }
 
-    public int getFanMode() {
-        return fanMode;
+    public int getFanRevrs() {
+        return fanRevrs;
     }
 
-    public void setFanMode(int fanMode) {
-        this.fanMode = fanMode;
+    public void setFanRevrs(int fanRevrs) {
+        this.fanRevrs = fanRevrs;
     }
 }

--- a/src/main/java/org/openhab/binding/wizlighting/internal/entities/FanSpeedRequestParam.java
+++ b/src/main/java/org/openhab/binding/wizlighting/internal/entities/FanSpeedRequestParam.java
@@ -17,32 +17,31 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import com.google.gson.annotations.Expose;
 
 /**
- * This POJO represents one Fan Mode Request Param
+ * This POJO represents Fan Speed Request Param
  *
  * The outgoing JSON should look like this:
  *
- * {"id": 22, "method": "setPilot", "params": {"fanMode": 2}}
+ * {"id": 23, "method": "setPilot", "params": {"fanState": 1,"fanSpeed": 3}}
  *
  * extends {@link FanStateRequestParam} to always set {@code fanState}, similar to {@link DimmingRequestParam} and usual
  * fan remote behavior
- *
- * @see org.openhab.binding.wizlighting.internal.enums.WizLightingFanMode
  */
 @NonNullByDefault
-public class FanModeRequestParam extends FanStateRequestParam {
+public class FanSpeedRequestParam extends FanStateRequestParam {
+
     @Expose(serialize = true, deserialize = true)
-    private int fanMode;
+    private int fanSpeed; // min 1
 
-    public FanModeRequestParam(int sceneId) {
-        super(1);
-        this.fanMode = sceneId;
+    public FanSpeedRequestParam(int fanSpeed) {
+        super(1); // fanState = 1
+        this.fanSpeed = fanSpeed;
     }
 
-    public int getFanMode() {
-        return fanMode;
+    public int getFanSpeed() {
+        return fanSpeed;
     }
 
-    public void setFanMode(int fanMode) {
-        this.fanMode = fanMode;
+    public void setFanSpeed(int fanSpeed) {
+        this.fanSpeed = fanSpeed;
     }
 }

--- a/src/main/java/org/openhab/binding/wizlighting/internal/enums/WizLightingFanMode.java
+++ b/src/main/java/org/openhab/binding/wizlighting/internal/enums/WizLightingFanMode.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.wizlighting.internal.enums;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This enum represents the possible scene modes for fans.
+ */
+public enum WizLightingFanMode {
+    Standard("Standard", 1),
+    Breeze("Breeze", 2);
+
+    private String fanModeName;
+    private int modeId;
+
+    private WizLightingFanMode(final String fanModeName, final int modeId) {
+        this.fanModeName = fanModeName;
+        this.modeId = modeId;
+    }
+
+    /**
+     * Gets the fanMode name for request colorMode
+     *
+     * @return the fanMode name
+     */
+    public String getFanMode() {
+        return fanModeName;
+    }
+
+    public int getModeId() {
+        return modeId;
+    }
+
+    private static final Map<Integer, WizLightingFanMode> FAN_MODE_MAP_BY_ID;
+    private static final Map<String, WizLightingFanMode> FAN_MODE_MAP_BY_NAME;
+
+    static {
+        FAN_MODE_MAP_BY_ID = new HashMap<Integer, WizLightingFanMode>();
+        FAN_MODE_MAP_BY_NAME = new HashMap<String, WizLightingFanMode>();
+
+        for (WizLightingFanMode v : WizLightingFanMode.values()) {
+            FAN_MODE_MAP_BY_ID.put(v.modeId, v);
+            FAN_MODE_MAP_BY_NAME.put(v.fanModeName.toLowerCase().replaceAll("\\W+", ""), v);
+        }
+    }
+
+    public static WizLightingFanMode fromModeId(int id) {
+        return FAN_MODE_MAP_BY_ID.get(id);
+    }
+
+    public static WizLightingFanMode fromModeName(String name) {
+        WizLightingFanMode r = null;
+        if (name != null && !"".equals(name)) {
+            r = FAN_MODE_MAP_BY_NAME.get(name.toLowerCase().replaceAll("\\W+", ""));
+        }
+        return r;
+    }
+}

--- a/src/main/java/org/openhab/binding/wizlighting/internal/handler/WizLightingHandler.java
+++ b/src/main/java/org/openhab/binding/wizlighting/internal/handler/WizLightingHandler.java
@@ -317,9 +317,10 @@ public class WizLightingHandler extends BaseThingHandler {
     }
 
     private void handleFanOnOffCommand(OnOffType onOff) {
-        logger.trace("[{}] Setting fan state to {}.", config.bulbIpAddress, onOff.toString());
-        setPilotCommand(new FanStateRequestParam(onOff == OnOffType.ON ? 1 : 0));
-        mostRecentState.state = onOff == OnOffType.ON;
+        int fanState = onOff == OnOffType.ON ? 1 : 0;
+        logger.trace("[{}] Setting fan state to {}.", config.bulbIpAddress, fanState);
+        setPilotCommand(new FanStateRequestParam(fanState));
+        mostRecentState.fanState = fanState;
     }
 
     private void handleFanReverseOnOffCommand(OnOffType onOff) {

--- a/src/main/java/org/openhab/binding/wizlighting/internal/handler/WizLightingHandler.java
+++ b/src/main/java/org/openhab/binding/wizlighting/internal/handler/WizLightingHandler.java
@@ -380,7 +380,7 @@ public class WizLightingHandler extends BaseThingHandler {
         }
         logger.trace("[{}] Changing dynamic light mode speed from {}% to {}%.", config.bulbIpAddress, oldSpeed,
                 newSpeed);
-        handleTemperatureCommand(new PercentType(newSpeed));
+        handleSpeedCommand(new PercentType(newSpeed));
     }
 
     private void handleFanSpeedCommand(DecimalType command) {

--- a/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/src/main/resources/OH-INF/thing/thing-types.xml
@@ -79,7 +79,15 @@
 		<description>Supports WiZ Ceiling Fans</description>
 
 		<channels>
+			<!-- light channels -->
+			<channel id="dimming" typeId="system.brightness"/>
+			<channel id="state" typeId="system.power"/>
+			<!-- fan channels -->
 			<channel id="fanState" typeId="system.power"/>
+			<channel id="fanMode" typeId="fanMode"/>
+			<!-- status channels -->
+			<channel id="signalstrength" typeId="system.signal-strength"/>
+			<channel id="lastUpdate" typeId="lastUpdate"/>
 		</channels>
 		<config-description-ref uri="thing-type:wiz:light"/>
 	</thing-type>
@@ -125,6 +133,20 @@
 				<option value="30">Golden White</option>
 				<option value="31">Pulse</option>
 				<option value="32">Steampunk</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<channel-type id="fanMode">
+		<item-type>String</item-type>
+		<label>Fan Mode</label>
+		<tags>
+			<tag>Lighting</tag>
+		</tags>
+		<state pattern="String" readOnly="false">
+			<options>
+				<option value="1">Standard</option>
+				<option value="2">Breeze</option>
 			</options>
 		</state>
 	</channel-type>

--- a/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/src/main/resources/OH-INF/thing/thing-types.xml
@@ -85,6 +85,8 @@
 			<!-- fan channels -->
 			<channel id="fanState" typeId="system.power"/>
 			<channel id="fanMode" typeId="fanMode"/>
+			<channel id="fanSpeed" typeId="fanSpeed"/>
+			<channel id="fanRevrs" typeId="fanRevrs"/>
 			<!-- status channels -->
 			<channel id="signalstrength" typeId="system.signal-strength"/>
 			<channel id="lastUpdate" typeId="lastUpdate"/>
@@ -137,6 +139,15 @@
 		</state>
 	</channel-type>
 
+	<channel-type id="speed">
+		<item-type>Dimmer</item-type>
+		<label>Dynamic Light Mode Speed</label>
+		<description>Speed of color/intensity changes in dynamic light modes</description>
+		<tags>
+			<tag>Lighting</tag>
+		</tags>
+	</channel-type>
+
 	<channel-type id="fanMode">
 		<item-type>String</item-type>
 		<label>Fan Mode</label>
@@ -151,10 +162,20 @@
 		</state>
 	</channel-type>
 
-	<channel-type id="speed">
-		<item-type>Dimmer</item-type>
-		<label>Dynamic Light Mode Speed</label>
-		<description>Speed of color/intensity changes in dynamic light modes</description>
+	<channel-type id="fanSpeed">
+		<item-type>Number</item-type>
+		<label>Fan Speed</label>
+		<description>Fan speed</description>
+		<tags>
+			<tag>Lighting</tag>
+		</tags>
+		<state min="1" step="1" readOnly="false"></state>
+	</channel-type>
+
+	<channel-type id="fanRevrs">
+		<item-type>Switch</item-type>
+		<label>Fan Reverse</label>
+		<description>Fan direction for switching to winter mode</description>
 		<tags>
 			<tag>Lighting</tag>
 		</tags>


### PR DESCRIPTION
Added the missing channels for fan support. Not entirely sure about the `thing-types.xml` changes, especially fan speed. I've managed to set speed from OH, but item definition required adding of metadata to work nicely. Not sure if there's a better way. Other than that it's mostly monkey-see-monkey-do (aka copy-paste), so please put extra attention on potential copy-paste-mistakes when reviewing. I've double and triple-checked but you never know, right?

Taking about copy-paste-errors, I've also found an error in the `fanState` command handling that caused the UI behavior that made me think the `Thread.sleep(..)` was necessary.

Also there seems to be a wrong method called in `handleIncreaseDecreaseSpeedCommand(..)` that I've corrected.

Regarding `fanMode`, the WiZ app shows this as a "Breeze" toggle. Local testing confirmed `1` and `2` as only accepted values by my controller. At least for my fan "Breeze" is some kind of weird pulsing I'd deem not very useful but anyway.

Fixes #3 